### PR TITLE
Add update_service impl to prevent NotImplementedError

### DIFF
--- a/discover.py
+++ b/discover.py
@@ -50,6 +50,9 @@ class TinxyServiceListener(ServiceListener):
                 return device
         return None
 
+    def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        print(f"Service {name} updated")
+
 
 zeroconf = Zeroconf()
 listener = TinxyServiceListener()


### PR DESCRIPTION
Without this change, the script errors out in the end with 

```
--------------------------------------------------
Exception in thread zeroconf-ServiceBrowser-_http._tcp-1350985:
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "src/zeroconf/_services/browser.py", line 811, in zeroconf._services.browser.ServiceBrowser.run
  File "src/zeroconf/_services/browser.py", line 730, in zeroconf._services.browser._ServiceBrowserBase._fire_service_state_changed_event
  File "src/zeroconf/_services/browser.py", line 740, in zeroconf._services.browser._ServiceBrowserBase._fire_service_state_changed_event
  File "src/zeroconf/_services/__init__.py", line 56, in zeroconf._services.Signal.fire
  File "src/zeroconf/_services/browser.py", line 305, in zeroconf._services.browser._on_change_dispatcher
  File "src/zeroconf/_services/__init__.py", line 45, in zeroconf._services.ServiceListener.update_service
NotImplementedError
```